### PR TITLE
Regex: Compatibility with the provided code skeleton and PDF tests

### DIFF
--- a/tpx-regex/src/Automaton.hs
+++ b/tpx-regex/src/Automaton.hs
@@ -1,17 +1,25 @@
 -- PART 2 – Simulating Automata
 
 module Automaton
--- ( Automaton (..),
---   Input (..),
---   State,
---   TransTable,
---   accepts,
---   maxState,
---   mkTransTable,
---   exampleAutomaton1,
---   exampleAutomaton2,
---   exampleAutomaton3,
--- )
+  ( Automaton (..),
+    Input (..),
+    State,
+    TransTable,
+    accepts,
+    maxState,
+    mkTransTable,
+    exampleAutomaton1,
+    exampleAutomaton2,
+    exampleAutomaton3,
+    -- Internal functions
+    -- (exported for testing)
+    alphabet,
+    states,
+    transFunc,
+    untilFixpoint,
+    epsilonClosure,
+    reachedStates,
+  )
 where
 
 import Data.List qualified as L
@@ -35,7 +43,7 @@ data Automaton
     transTable :: TransTable,
     acceptStates :: [State]
   }
-  deriving Eq
+  deriving (Eq)
 
 instance Show Automaton where
   show auto =

--- a/tpx-regex/src/Regex.hs
+++ b/tpx-regex/src/Regex.hs
@@ -1,15 +1,19 @@
 -- PART 1 – Parsing Regular Expressions
 
 module Regex
-  -- ( Regex (..),
-  --   toRegex,
-  -- )
+  ( Regex (..),
+    toRegex,
+    -- Internal functions
+    -- (exported for testing)
+    parseAtom,
+    parseFactor,
+    parseTerm,
+    parseRegex,
+  )
 where
 
 import Result
 import Word
-
-import Data.Char (isAlpha)
 
 data Regex
   = EmptyLang
@@ -18,7 +22,7 @@ data Regex
   | Concat Regex Regex
   | Union Regex Regex
   | Star Regex
-  deriving Eq
+  deriving (Eq)
 
 instance Show Regex where
   show = (<> "\n") . show' []

--- a/tpx-regex/src/Thompson.hs
+++ b/tpx-regex/src/Thompson.hs
@@ -1,8 +1,19 @@
 -- PART 3 – From Regular Expressions to Automata
 
 module Thompson
--- ( match,
--- )
+  ( match,
+    -- Internal functions
+    -- (exported for testing)
+    emptyAutomaton,
+    epsilonAutomaton,
+    letterAutomaton,
+    merge,
+    mapToStates,
+    concat,
+    union,
+    star,
+    toAutomaton,
+  )
 where
 
 import Automaton

--- a/tpx-regex/tests/RegexTests.hs
+++ b/tpx-regex/tests/RegexTests.hs
@@ -90,9 +90,9 @@ test_toRegex =
       testCase "failure on hanging open parenthesis" $
         toRegex "a(" @?= Left "Unexpected end of string",
       testCase "non-empty suffix (closing parenthesis)" $
-        toRegex "a)" @?= Left "Unexpected suffix : )",
+        toRegex "a)" @?= Left "Unexpected suffix: )",
       testCase "non-empy suffix (lots of stuff)" $
-        toRegex "a#@!?%" @?= Left "Unexpected suffix : #@!?%",
+        toRegex "a#@!?%" @?= Left "Unexpected suffix: #@!?%",
       testCase "complex regex 1" $
         toRegex "(a*b|c)d"
           @?= Right


### PR DESCRIPTION
Very minor changes so that the unit tests are 100% compatible with the provided code skeleton and the tests in the PDF.